### PR TITLE
Add a function call to notify the result of the pairing.

### DIFF
--- a/transferring_idm_with_secure_ble2/secure_ble_settings.ino
+++ b/transferring_idm_with_secure_ble2/secure_ble_settings.ino
@@ -57,8 +57,10 @@ class MySecurity : public BLESecurityCallbacks {  // BLE security with pass key
       // ペアリング完了
       Serial.println("auth success");
       ESP_LOGI(LOG_TAG, "Starting BLE work!");
+      notify_data("auth success");
     }else{
       // ペアリング失敗
+      notify_data("auth failed");
       deviceConnected = false;
       Serial.println("auth failed");
       ESP_LOGI(LOG_TAG, "Starting BLE failed!");


### PR DESCRIPTION
I modify to add a call to the notify_data function to notify the result of the pairing process to the central.